### PR TITLE
Install examples the pretty way

### DIFF
--- a/Manifest.in
+++ b/Manifest.in
@@ -1,0 +1,1 @@
+recursive-include kivy3 *.*

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,27 @@
 #!/usr/bin/env python
 
 from setuptools import find_packages, setup
+from os.path import join, dirname
+from os import walk
 
-setup(name='kivy3',
-      version='0.1',
-      description='Kivy extensions for 3D graphics',
-      author='Niko Skrypnik',
-      author_email='nskrypnik@gmail.com',
-      packages=find_packages(exclude=("tests",)),
-      requires=['kivy', ]
-    )
+examples = {}
+for root, subFolders, files in walk('examples'):
+    for fn in files:
+        ext = fn.split('.')[-1].lower()
+        filename = join(root, fn)
+        directory = '%s%s' % ('share/kivy3-', dirname(filename))
+        if directory not in examples:
+            examples[directory] = []
+        examples[directory].append(filename)
+
+setup(
+    name='kivy3',
+    version='0.1',
+    description='Kivy extensions for 3D graphics',
+    author='Niko Skrypnik',
+    author_email='nskrypnik@gmail.com',
+    include_package_data=True,
+    packages=find_packages(exclude=("tests",)),
+    data_files=list(examples.items()),
+    requires=['kivy', ]
+)


### PR DESCRIPTION
Put the `examples` folder into `<python dir>\share\kivy3-examples` as Kivy does. It's more intuitive. Also with `Manifest.in` it makes sure `pip` will install _every_ file that will be inside the folder, therefore `.glsl` or `.obj`,or other non-python files will be successfully included without much effort. Feel free to request edits of extensions that shouls be added via `Manifest.in` (you might not want to include _everything_ == `*.*`).

Edit: rebased.