### PR TITLE
Add python .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Basic .gitattributes for a python repo.
+
+# Source files
+# ============
+*.pxd   text
+*.py    text
+*.py3   text
+*.pyw   text
+*.pyx   text
+
+# Binary files
+# ============
+*.db    binary
+*.p     binary
+*.pkl   binary
+*.pyc   binary
+*.pyd   binary
+*.pyo   binary
+*.obj   binary
+
+# Note: .db, .p, and .pkl files are associated
+# with the python modules ``pickle``, ``dbm.*``,
+# ``shelve``, ``marshal``, ``anydbm``, & ``bsddb``
+# (among others).


### PR DESCRIPTION
Add python gitattributes to prevent line endings collisions, such as with `.obj` files that are generated and should be treated as binaries, not as casual files and other python/cython files when contributing from multiple platforms.