### PR TITLE
Allow ints in Material, put defaults to kwargs

### DIFF
--- a/kivy3/materials.py
+++ b/kivy3/materials.py
@@ -41,15 +41,19 @@ def set_attribute_to_uniform(attr_name, uniform_var):
 
 class Material(ChangeState):
 
-    def __init__(self, **kw):
-        self.map = kw.pop("map", None)
+    def __init__(self, map=None, transparency=1.0, color=(1, 1, 1),
+                 diffuse=(0, 0, 0), specular=(0, 0, 0),
+                 shininess=10.0, **kwargs):
+        self.map = map
         super(Material, self).__init__()
-        kw.setdefault("transparency", 1.)
-        kw.setdefault("color", (1., 1., 1.))
-        kw.setdefault("diffuse", (0., 0., 0.))
-        kw.setdefault("specular", (0., 0., 0.))
-        kw.setdefault("shininess", 10.)
-        for k, v in kw.iteritems():
+        transparency = float(transparency)
+        color = tuple(float(c) for c in color)
+        diffuse = tuple(float(d) for d in diffuse)
+        specular = tuple(float(s) for s in specular)
+        shininess = float(shininess)
+
+        # set attribute from locals
+        for k, v in locals().items():
             setattr(self, k, v)
 
     def __setattr__(self, k, v):


### PR DESCRIPTION
Explicitly state default values in kwargs (py3 likes that anyway) and allow using of integers in Material properties for example:

        cube_mat = Material(
            color=(1, 1, 1),     # is black, because integers, should be white
            diffuse=(0, 0, 0),
            specular=(0, 0, 0)
        )

Also that using of `dict.iteritems()` was replaced just with `items()`, which in py2 creates a list and in py3 is already a generator, but there shouldn't be a visible difference unless there's pushed some big list into `kwargs`, which wouldn't be used anyway (make user responsible of what is pushed into `__init__` + allow py3 to work)