### PR TITLE
Change scale to AliasProperty

### DIFF
--- a/kivy3/core/object3d.py
+++ b/kivy3/core/object3d.py
@@ -50,7 +50,7 @@ class Object3D(EventDispatcher):
         self.children = list()
         self.parent = None
 
-        self.scale = Scale(1., 1., 1.)
+        self._scale = Scale(1., 1., 1.)
         self._position = Vector3(0, 0, 0)
         self._rotation = Vector3(0, 0, 0)
         self._position.set_change_cb(self.on_pos_changed)
@@ -104,6 +104,17 @@ class Object3D(EventDispatcher):
 
     rotation = AliasProperty(_get_rotation, _set_rotation)
     rot = rotation
+
+    def _set_scale(self, val):
+        if isinstance(val, Scale):
+            self._scale = val
+        else:
+            self._scale = Scale(*val)
+
+    def _get_scale(self):
+        return self._scale
+
+    scale = AliasProperty(_get_scale, _set_scale)
 
     def on_pos_changed(self, coord, v):
         """ Some coordinate was changed """


### PR DESCRIPTION
As the title says, change it to a prettier variable for using with the default Kivy's `Scale`. I haven't found a way how to increment it as a whole though (`mesh.scale += Scale(...)`), so maybe there's something too, but it works for individual parts e.g.:

    mesh.scale.origin = (1, 0, 0)
    mesh.scale.x += 0.1