### PR TITLE
Add RUB vectors and viewport matrix

### DIFF
--- a/kivy3/cameras/camera.py
+++ b/kivy3/cameras/camera.py
@@ -49,9 +49,10 @@ class Camera(Object3D, EventDispatcher):
     """
 
     scale = NumericProperty(1.0)
-    right = ObjectProperty(Vector3(1, 0, 0))
+    _right = ObjectProperty(Vector3(1, 0, 0))
+    _up = ObjectProperty(Vector3(0, 1, 0))
+    _back = ObjectProperty(Vector3(0, 0, 1))
     up = ObjectProperty(Vector3(0, 1, 0))
-    back = ObjectProperty(Vector3(0, 0, 1))
 
     def __init__(self):
         super(Camera, self).__init__()
@@ -92,9 +93,9 @@ class Camera(Object3D, EventDispatcher):
         self.modelview_matrix = m
 
         # set camera vectors from view matrix
-        self.right = Vector3(m[0], m[1], m[2])
-        self.up = Vector3(m[4], m[5], m[6])
-        self.back = Vector3(m[8], m[9], m[10])
+        self._right = Vector3(m[0], m[1], m[2])
+        self._up = Vector3(m[4], m[5], m[6])
+        self._back = Vector3(m[8], m[9], m[10])
         self._look_at = v
         self.update()
 

--- a/kivy3/cameras/camera.py
+++ b/kivy3/cameras/camera.py
@@ -49,12 +49,15 @@ class Camera(Object3D, EventDispatcher):
     """
 
     scale = NumericProperty(1.0)
+    right = ObjectProperty(Vector3(1, 0, 0))
     up = ObjectProperty(Vector3(0, 1, 0))
+    back = ObjectProperty(Vector3(0, 0, 1))
 
     def __init__(self):
         super(Camera, self).__init__()
         self.projection_matrix = Matrix()
         self.modelview_matrix = Matrix()
+        self.viewport_matrix = (0, 0, 0, 0)
         self.renderer = None  # renderer camera is bound to
         self._look_at = None
         self.look_at(Vector3(0, 0, -1))
@@ -87,6 +90,11 @@ class Camera(Object3D, EventDispatcher):
         m = m.rotate(radians(self.rot.y), 0.0, 1.0, 0.0)
         m = m.rotate(radians(self.rot.z), 0.0, 0.0, 1.0)
         self.modelview_matrix = m
+
+        # set camera vectors from view matrix
+        self.right = Vector3(m[0], m[1], m[2])
+        self.up = Vector3(m[4], m[5], m[6])
+        self.back = Vector3(m[8], m[9], m[10])
         self._look_at = v
         self.update()
 
@@ -97,6 +105,12 @@ class Camera(Object3D, EventDispatcher):
     def update(self):
         if self.renderer:
             self.renderer._update_matrices()
+            self.viewport_matrix = (
+                self.renderer._viewport.pos[0],
+                self.renderer._viewport.pos[1],
+                self.renderer._viewport.size[0],
+                self.renderer._viewport.size[1]
+            )
 
     def update_projection_matrix(self):
         """ This function should be overridden in the subclasses

--- a/kivy3/cameras/camera.py
+++ b/kivy3/cameras/camera.py
@@ -39,9 +39,11 @@ from kivy.properties import NumericProperty, ListProperty, ObjectProperty, \
     AliasProperty
 from kivy.graphics.transformation import Matrix
 from ..math.vectors import Vector3
+from ..core.object3d import Object3D
+from math import radians
 
 
-class Camera(EventDispatcher):
+class Camera(Object3D, EventDispatcher):
     """
     Base camera class
     """
@@ -54,25 +56,13 @@ class Camera(EventDispatcher):
         self.projection_matrix = Matrix()
         self.modelview_matrix = Matrix()
         self.renderer = None  # renderer camera is bound to
-        self._position = Vector3(0, 0, 0)
-        self._position.set_change_cb(self.on_pos_changed)
         self._look_at = None
         self.look_at(Vector3(0, 0, -1))
 
     def _set_position(self, val):
-        if isinstance(val, Vector3):
-            self._position = val
-        else:
-            self._position = Vector3(val)
-        self._position.set_change_cb(self.on_pos_changed)
+        super(Camera, self).on_pos_changed(val)
         self.look_at(self._look_at)
         self.update()
-
-    def _get_position(self):
-        return self._position
-
-    position = AliasProperty(_get_position, _set_position)
-    pos = position  # just shortcut
 
     def on_pos_changed(self, coord, v):
         """ Camera position was changed """
@@ -93,6 +83,9 @@ class Camera(EventDispatcher):
         pos = self._position * -1
         m = m.look_at(pos[0], pos[1], pos[2], v[0], v[1], v[2],
                       self.up[0], self.up[1], self.up[2])
+        m = m.rotate(radians(self.rot.x), 1.0, 0.0, 0.0)
+        m = m.rotate(radians(self.rot.y), 0.0, 1.0, 0.0)
+        m = m.rotate(radians(self.rot.z), 0.0, 0.0, 1.0)
         self.modelview_matrix = m
         self._look_at = v
         self.update()


### PR DESCRIPTION
Working with PR #16 this PR includes the `right`, `up`, `back` vectors taken directly from modelview matrix for easier use for users + refreshes them when the matrices are updated in renderer (RUB should be up-to-date, but until now the `up` was only `Y` axis - no refresh from modelview matrix).