### PR TITLE
Fix inverted camera position

### DIFF
--- a/kivy3/cameras/camera.py
+++ b/kivy3/cameras/camera.py
@@ -90,7 +90,7 @@ class Camera(EventDispatcher):
         if len(v) == 1:
             v = v[0]
         m = Matrix()
-        pos = self._position * -1
+        pos = self._position
         m = m.look_at(pos[0], pos[1], pos[2], v[0], v[1], v[2],
                       self.up[0], self.up[1], self.up[2])
         self.modelview_matrix = m


### PR DESCRIPTION
Judging from [space](https://upload.wikimedia.org/wikipedia/commons/8/83/Coord_planes_color.svg) Z axis after this change is heading towards user/keyboard, which seems more reasonable to use (and invert only Z locally in code) to have pos corresponding to the real position on the screen i.e.:

    camera.pos.x += 1  # move right
    camera.pos.y += 1  # move up
    camera.pos.z += 1  # move towards user
    camera.pos.z -= 1  # move from user (behind display)