### PR TITLE
Add basic light api

### DIFF
--- a/kivy3/cameras/camera.py
+++ b/kivy3/cameras/camera.py
@@ -53,6 +53,7 @@ class Camera(EventDispatcher):
         super(Camera, self).__init__()
         self.projection_matrix = Matrix()
         self.modelview_matrix = Matrix()
+        self.model_matrix = Matrix()
         self.renderer = None  # renderer camera is bound to
         self._position = Vector3(0, 0, 0)
         self._position.set_change_cb(self.on_pos_changed)
@@ -103,6 +104,9 @@ class Camera(EventDispatcher):
 
     def update(self):
         if self.renderer:
+            model_matrix = self.modelview_matrix.multiply(
+                self.renderer.fbo['view_mat'].inverse())
+            self.model_matrix = model_matrix
             self.renderer._update_matrices()
 
     def update_projection_matrix(self):

--- a/kivy3/default.glsl
+++ b/kivy3/default.glsl
@@ -3,26 +3,36 @@
     precision highp float;
 #endif
 
-attribute vec3  v_pos;
-attribute vec3  v_normal;
-attribute vec4  v_color;
-attribute vec2  v_tc0;
+// inside VS, read-only
+attribute vec3 v_pos;
+attribute vec3 v_normal;
+attribute vec4 v_color;
+attribute vec2 v_tc0;
 
+// from python, read-only
 uniform mat4 modelview_mat;
 uniform mat4 projection_mat;
-uniform float Tr;
+uniform mat4 normal_mat;
+uniform mat4 model_mat;
+uniform mat4 view_mat;
 
-varying vec4 frag_color;
-varying vec2 uv_vec;
+// used later in FS
 varying vec4 normal_vec;
 varying vec4 vertex_pos;
+varying vec4 frag_color;
+varying vec2 uv_vec;
+
 
 void main (void) {
-    vec4 pos = modelview_mat * vec4(v_pos,1.0);
+    // fetch read-only for later use
+    normal_vec = vec4(v_normal, 0.0);
     frag_color = v_color;
     uv_vec = v_tc0;
+
+    vec4 pos = modelview_mat * vec4(v_pos, 1.0);
     vertex_pos = pos;
-    normal_vec = vec4(v_normal,0.0);
+
+    // required shader clip-space output
     gl_Position = projection_mat * pos;
 }
 
@@ -32,30 +42,58 @@ void main (void) {
     precision highp float;
 #endif
 
+// from VS
 varying vec4 normal_vec;
 varying vec4 vertex_pos;
 varying vec4 frag_color;
 varying vec2 uv_vec;
 
+// from python, read-only
+uniform mat4 modelview_mat;
+uniform mat4 projection_mat;
 uniform mat4 normal_mat;
+uniform mat4 model_mat;
+uniform mat4 view_mat;
+
+uniform vec3 camera_pos;
+uniform vec3 Ka; // color (ambient)
 uniform vec3 Kd; // diffuse color
-uniform vec3 Ka; // color
 uniform vec3 Ks; // specular color
 uniform float Tr; // transparency
 uniform float Ns; // shininess
+uniform float tex_ratio;
 
+uniform vec3 light_pos;
+uniform float light_intensity;
 
-uniform sampler2D tex;
+uniform sampler2D tex; // texture
+
 
 void main (void){
-    vec4 v_normal = normalize( normal_mat * normal_vec );
-    vec4 v_light = normalize( vec4(0,0,0,1) - vertex_pos );
+    // pull colors from texture
+    vec4 tex_color = texture2D(tex, uv_vec);
 
-    vec3 Ia = Ka;
+    // force lightPos to lower-left (like in Kivy)
+    vec4 lightPos = model_mat * vec4(light_pos, 0.0) - gl_FragCoord;
+    float lightPosLen = length(lightPos);
+
+    vec4 v_normal = normalize(normal_mat * normal_vec);
+    vec4 vertex_world = modelview_mat * vertex_pos;
+    vec4 v_light = vec4(light_pos, 1.0) - vertex_world;
+
+    // set ambient, diffuse, specular color
+    vec3 Ia = Ka * light_intensity / lightPosLen;
     vec3 Id = Kd * max(dot(v_light, v_normal), 0.0);
     vec3 Is = Ks * pow(max(dot(v_light, v_normal), 0.0), Ns);
 
-    vec4 tex_color = texture2D(tex, uv_vec);
+    // modify texture color by light intensity
+    tex_color = vec4(
+        tex_color.rgb * light_intensity / lightPosLen,
+        tex_color[3]
+    );
+
+    // required shader output
+    // window-space fragment color with texture
     gl_FragColor = vec4(Ia + Id + Is, Tr);
-    gl_FragColor = gl_FragColor * tex_color;
+    gl_FragColor = mix(gl_FragColor, tex_color, tex_ratio);
 }

--- a/kivy3/light.py
+++ b/kivy3/light.py
@@ -1,0 +1,53 @@
+from kivy.core.window import Window
+from kivy.event import EventDispatcher
+from kivy.properties import (
+    NumericProperty,
+    ReferenceListProperty
+)
+
+# Map for light attributes to shader
+# uniform variables
+LIGHT_TO_SHADER_MAP = {
+    "pos": "light_pos",
+    "intensity": "light_intensity",
+}
+
+
+class LightError(Exception):
+    pass
+
+
+class Light(EventDispatcher):
+
+    # ensure floats everywhere,
+    # otherwise it breaks stuff
+    pos_x = NumericProperty(0.0)
+    pos_y = NumericProperty(0.0)
+    pos_z = NumericProperty(0.0)
+    pos = ReferenceListProperty(pos_x, pos_y, pos_z)
+    intensity = NumericProperty(1000.0)
+
+    def __init__(self, renderer=None, intensity=None,
+                 pos=None, origin=None, **kwargs):
+        if not renderer:
+            raise LightError("Renderer is not defined!")
+        super(Light, self).__init__(**kwargs)
+        self.renderer = renderer
+        self.on_pos(self, pos if pos else self.pos)
+        self.on_intensity(self, intensity if intensity else self.intensity)
+
+    def on_pos(self, instance, value):
+        self._update_fbo(
+            'pos',
+            (float(value[0]),
+             float(value[1]),
+             float(value[2]))
+        )
+
+    def on_intensity(self, instance, value):
+        self._update_fbo('intensity', float(value))
+
+    def _update_fbo(self, key, value):
+        if key in LIGHT_TO_SHADER_MAP:
+            uniform_var = LIGHT_TO_SHADER_MAP[key]
+            self.renderer.fbo[uniform_var] = value

--- a/kivy3/materials.py
+++ b/kivy3/materials.py
@@ -27,12 +27,12 @@ from kivy.graphics import ChangeState
 # Map for material attributes to shader
 # uniform variables
 MATERIAL_TO_SHADER_MAP = {
-                          "color": "Ka",
-                          "transparency": "Tr",
-                          "diffuse": "Kd",
-                          "specular": "Ks",
-                          "shininess": "Ns",  # specular coefficient
-                          }
+    "color": "Ka",
+    "transparency": "Tr",
+    "diffuse": "Kd",
+    "specular": "Ks",
+    "shininess": "Ns",  # specular coefficient
+}
 
 
 def set_attribute_to_uniform(attr_name, uniform_var):

--- a/kivy3/renderer.py
+++ b/kivy3/renderer.py
@@ -40,12 +40,14 @@ import kivy3
 from kivy.uix.widget import Widget
 from kivy.clock import Clock
 from kivy.graphics.fbo import Fbo
+from kivy.core.window import Window
 from kivy.graphics.instructions import InstructionGroup
 from kivy.graphics.opengl import glEnable, glDisable, GL_DEPTH_TEST
+from kivy.graphics.transformation import Matrix
 from kivy.graphics import Callback, PushMatrix, PopMatrix, \
                           Rectangle, Canvas, UpdateNormalMatrix
 
-
+from .light import Light
 kivy3_path = os.path.abspath(os.path.dirname(kivy3.__file__))
 
 
@@ -69,6 +71,7 @@ class Renderer(Widget):
         self.texture = self.fbo.texture
         self.camera = None
         self.scene = None
+        self.main_light = Light(renderer=self)
 
     def _config_fbo(self):
         # set shader file here
@@ -114,6 +117,10 @@ class Renderer(Widget):
         if self.camera:
             self.fbo['projection_mat'] = self.camera.projection_matrix
             self.fbo['modelview_mat'] = self.camera.modelview_matrix
+            self.fbo['model_mat'] = self.camera.model_matrix
+            self.fbo['camera_pos'] = [float(p) for p in self.camera.position]
+            self.fbo['view_mat'] = Matrix().rotate(
+                Window.rotation, 0.0, 0.0, 1.0)
         else:
             raise RendererError("Camera is not defined for renderer")
 


### PR DESCRIPTION
I noticed that matrices are set in `renderer.py/Renderer._config_fbo()`, so I put there new useful to have matrices when working with the shader:

* model matrix
* view matrix

Judging from [kivy source](https://github.com/kivy/kivy/blob/5913d861f45119dfff0b6cb5d004e6f79858563c/kivy/core/window/__init__.py#L1167) I presume that the original view matrix is just this little piece:

    Matrix().rotate(Window.rotation, 0, 0, 1)

and I also add position of a camera, which might be later useful with more complex lighting, such as directional lights.

Then I made some comments directly in the glsl file, so that even beginner could understand each variable's origin and exposed all useful matrices in both vertex and fragment shader.

Later there might be included some light manager rather than simple `self.main_light = Light(...)`, but for now I can't figure how to do it in a way it'd work even in glsl without annoying changes.

The `light.py` contains simple variables `pos` and `intensity` which manage the position of the light on surfaces and obviously, its intensity. I left the intensity at `1000.0` as it matches the original light the best.

**Screenshots:**

* light shining from the right side with quite high intensity
* light shining with almost zero intensity. `intensity == 0.0` is obviously dark/night.

both with different positions.

![image](https://cloud.githubusercontent.com/assets/8825439/21469349/5fadd1fa-ca46-11e6-8208-a4d48cca8fe8.png)

Just a note: I put the matrix update function at the bottom (after the values inside matrices are changed), but if after the merge the matrix update function isn't at the bottom, it might be a good idea to put it there manually:

```
     def update(self):
         if self.renderer:
-            model_matrix = self.modelview_matrix.multiply(
-                self.renderer.fbo['view_mat'].inverse())
-            self.model_matrix = model_matrix
-            self.renderer._update_matrices()
             self.viewport_matrix = (
                 self.renderer._viewport.pos[0],
                 self.renderer._viewport.pos[1],
                 self.renderer._viewport.size[0],
                 self.renderer._viewport.size[1]
             )
+            model_matrix = self.modelview_matrix.multiply(
+                self.renderer.fbo['view_mat'].inverse())
+            self.model_matrix = model_matrix
+            self.renderer._update_matrices()
```

Side note: I had problems with the light, because in the previous version of shader (with just fetched uniforms of `light_pos` and `light_intensity`) the light was for some reason **_bound_** relatively to the camera i.e. when the camera rotated left, the light went left too and it all looked like a headlight. After applied `model_mat` the light behaves normally, I think (in the worst situation, it's not relative to the camera at least).