### PR TITLE
Object loader and Mesh improvements

### DIFF
--- a/kivy3/loaders/objloader.py
+++ b/kivy3/loaders/objloader.py
@@ -97,7 +97,10 @@ class WaveObject(object):
             raw_material = self.loader.mtl_contents[self.mtl_name]
             for k, v in raw_material.iteritems():
                 _k = self._mtl_map.get(k, None)
+                # XXX: also handle map_Ka and map_Ks
                 if k in ["map_Kd", ]:
+                    # XXX: map file path may contains spaces.
+                    #      current implementation fails.
                     map_path = os.path.join(mtl_dirname, v[0])
                     if not os.path.exists(map_path):
                         msg = u'WaveObject: Texture not found <{}>'

--- a/kivy3/loaders/objloader.py
+++ b/kivy3/loaders/objloader.py
@@ -188,21 +188,33 @@ class OBJLoader(BaseLoader):
             elif values[0] == 'f':
                 if not faces_section:
                     faces_section = True
-                face = []
-                texcoords = []
-                norms = []
-                for v in values[1:]:
-                    w = v.split('/')
-                    face.append(int(w[0]))
-                    if len(w) >= 2 and len(w[1]) > 0:
-                        texcoords.append(int(w[1]))
-                    else:
-                        texcoords.append(-1)
-                    if len(w) >= 3 and len(w[2]) > 0:
-                        norms.append(int(w[2]))
-                    else:
-                        norms.append(-1)
-                wvobj.faces.append((face, norms, texcoords))
+                # face values
+                f = values[1:]
+                # triangle
+                if len(f) == 3:
+                    fcs = [f]
+                # square, convert into two triangles
+                elif len(f) == 4:
+                    fcs = [
+                        f[:3],
+                        [f[0], f[2], f[3]]
+                    ]
+                for f in fcs:
+                    face = []
+                    texcoords = []
+                    norms = []
+                    for v in f:
+                        w = v.split('/')
+                        face.append(int(w[0]))
+                        if len(w) >= 2 and len(w[1]) > 0:
+                            texcoords.append(int(w[1]))
+                        else:
+                            texcoords.append(-1)
+                        if len(w) >= 3 and len(w[2]) > 0:
+                            norms.append(int(w[2]))
+                        else:
+                            norms.append(-1)
+                    wvobj.faces.append((face, norms, texcoords))
         yield wvobj
 
     def load(self, source, **kw):

--- a/kivy3/loaders/objloader.py
+++ b/kivy3/loaders/objloader.py
@@ -31,6 +31,7 @@ Loaders for Wavefront format .obj files
 import os
 from .loader import BaseLoader
 from kivy.core.image import Image
+from kivy.logger import Logger
 from kivy3 import Object3D, Mesh, Material, Vector2
 from kivy3.core.geometry import Geometry
 from kivy3.core.face3 import Face3
@@ -98,6 +99,10 @@ class WaveObject(object):
                 _k = self._mtl_map.get(k, None)
                 if k in ["map_Kd", ]:
                     map_path = os.path.join(mtl_dirname, v[0])
+                    if not os.path.exists(map_path):
+                        msg = u'WaveObject: Texture not found <{}>'
+                        Logger.warning(msg.format(map_path))
+                        continue
                     tex = Image(map_path).texture
                     material.map = tex
                     continue

--- a/kivy3/objects/mesh.py
+++ b/kivy3/objects/mesh.py
@@ -26,9 +26,12 @@ from kivy.graphics import Mesh as KivyMesh
 from kivy3 import Vector3
 from kivy3.core.object3d import Object3D
 
-DEFAULT_VERTEX_FORMAT = [('v_pos', 3, 'float'),
-            ('v_normal', 3, 'float'),
-            ('v_tc0', 2, 'float')]
+DEFAULT_VERTEX_FORMAT = [
+    ('v_pos', 3, 'float'),
+    ('v_normal', 3, 'float'),
+    ('v_tc0', 2, 'float')
+]
+DEFAULT_MESH_MODE = 'triangles'
 
 
 class Mesh(Object3D):
@@ -38,7 +41,8 @@ class Mesh(Object3D):
         self.geometry = geometry
         self.material = material
         self.mtl = self.material  # shortcut for material property
-        self.vertex_format = kw.pop("vertex_format", DEFAULT_VERTEX_FORMAT)
+        self.vertex_format = kw.pop('vertex_format', DEFAULT_VERTEX_FORMAT)
+        self.mesh_mode = kw.pop('mesh_mode', DEFAULT_MESH_MODE)
         self.create_mesh()
 
     def create_mesh(self):
@@ -63,11 +67,17 @@ class Mesh(Object3D):
                     vertices.extend([0, 0])
                 indices.append(idx)
                 idx += 1
-        kw = {"vertices": vertices, "indices": indices,
-              "fmt": self.vertex_format, "mode": "triangles"
-              }
+        if idx >= 65535 - 1:
+            msg = 'Mesh must not contain more than 65535 indices, {} given'
+            raise ValueError(msg.format(idx + 1))
+        kw = dict(
+            vertices=vertices,
+            indices=indices,
+            fmt=self.vertex_format,
+            mode=self.mesh_mode
+        )
         if self.material.map:
-            kw["texture"] = self.material.map
+            kw['texture'] = self.material.map
         self._mesh = KivyMesh(**kw)
 
     def custom_instructions(self):


### PR DESCRIPTION
* Log warning in WaveObject.convert_to_mesh if texture file cannot be found instead of failing with an AttributeError.

* Convert square faces into two triangle faces when parsing obj files.

* Introduce ``mesh_mode`` on ``kivy3.objects.mesh.Mesh``.

* Throw ``ValueError`` if attempting to create Mesh with more than 65535 indices.